### PR TITLE
docs: add comprehensive README and LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,30 @@
+Purple Pen License
+
+Copyright © 2006-2007, Peter Golde
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+- Neither the name of Peter Golde, nor "Purple Pen", nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,106 @@
-# PurplePen
-Course setting program for orienteering races.
+# Purple Pen
+
+**Purple Pen** is a desktop course-setting program for orienteering races. It lets you design courses on a map, manage control points and course variations, produce control descriptions, and export print-ready materials.
+
+> **Status:** v4.0.0.110 Alpha 1 — the cross-platform Avalonia port is under active development.
+
+---
+
+## Features
+
+- **Map support** — OCAD (versions 6–12), OpenMapper (.omap), georeferenced PDF backgrounds, and bitmap templates
+- **Course design** — normal, score, and relay courses; map exchanges; course variations
+- **Control descriptions** — multi-language IOF symbol descriptions; print-ready layouts
+- **Export** — course PDFs, bitmap exports (PNG/JPEG), purple-pen XML course files (.ppen)
+- **Multi-language UI** — live language switching (English, French, German, Slovak, and more)
+- **Cross-platform rendering** — SkiaSharp backend for macOS/Linux; GDI+ for Windows
+
+---
+
+## Platform Support
+
+| Platform | Application | Status |
+|----------|-------------|--------|
+| macOS (Apple Silicon & Intel) | Avalonia (`src/AvPurplePen`) | Active development |
+| Windows | Avalonia (`src/AvPurplePen`) | Active development |
+| Windows | WinForms (`src/PurplePen`) | Legacy; feature-complete but not receiving new UI work |
+
+---
+
+## Getting Started
+
+### macOS
+
+See [MACOS.md](MACOS.md) for full prerequisites, build, publish, and troubleshooting instructions.
+
+Quick start:
+
+```bash
+# Prerequisites: .NET 10 SDK, Xcode Command Line Tools
+cd src
+dotnet run --project AvPurplePen/AvPurplePen.csproj
+```
+
+### Windows
+
+```bash
+cd src
+
+# Run the Avalonia app
+dotnet run --project AvPurplePen/AvPurplePen.csproj
+
+# Or build the legacy WinForms app (requires Visual Studio 2022)
+msbuild PurplePen/PurplePen.csproj /p:Configuration=Release
+```
+
+---
+
+## Running Tests
+
+```bash
+cd src
+
+# ViewModel unit tests (cross-platform, no UI)
+dotnet test PurplePenViewModels.Tests/PurplePenViewModels.Tests.csproj
+
+# Skia rendering tests
+dotnet test MapModel/Map_Skia.Tests/Map_Skia.Tests.csproj -f net10.0
+
+# Graphics2D abstraction tests
+dotnet test MapModel/Graphics2D.Tests/Graphics2D.Tests.csproj -f net10.0
+
+# PDF output tests
+dotnet test MapModel/Map_PDF.Tests/Map_PDF.Tests.csproj -f net10.0
+
+# WinForms integration tests (Windows only)
+dotnet test PurplePen_Tests/PurplePen_Tests.csproj
+```
+
+---
+
+## Architecture
+
+Purple Pen uses a layered MVC architecture:
+
+- **Controller** (`src/PurplePen/Controller.cs`) — central command coordinator; all UI operations flow through here
+- **EventDB** (`src/PurplePen/EventDB.cs`) — course and event data with automatic undo/redo via `UndoMgr`
+- **CourseView** (`src/PurplePen/CourseView.cs`) — immutable course snapshots for rendering
+- **IGraphicsTarget** (`src/MapModel/Graphics2D-Shared/IGraphicsTarget.cs`) — rendering abstraction; the same drawing commands target GDI+, SkiaSharp, WPF, PDF, Direct2D, and iOS backends
+- **CMYK colors throughout** — all colors use CMYK internally; backends convert to the platform color model as needed
+
+---
+
+## Contributing
+
+1. Fork the repository and create a branch: `git checkout -b issue-N-short-description`
+2. Make your changes following the coding conventions in [AGENTS.md](AGENTS.md)
+3. Run the relevant tests (see above)
+4. Open a pull request against `main`
+
+For larger changes, open an issue first to discuss the approach.
+
+---
+
+## License
+
+Copyright © 2006-2007, Peter Golde. See [LICENSE](LICENSE) for the full BSD 3-Clause license text.


### PR DESCRIPTION
## Summary

- Replaces the 2-line placeholder README with a comprehensive one covering purpose, features, platform support, build/test instructions, architecture overview, and contribution guidelines
- Creates a new `LICENSE` file with the full BSD 3-Clause text faithfully converted from `doc/userdocs/WebSite/license.htm` (copyright Peter Golde 2006-2007)

## Test plan

- [ ] Verify LICENSE text matches `doc/userdocs/WebSite/license.htm` exactly (copyright, three conditions, disclaimer)
- [ ] Verify README renders correctly on GitHub (headers, code blocks, tables)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)