### PR TITLE
Port SetPrintAreaDialog to Avalonia

### DIFF
--- a/src/AvPurplePen/UIText.resx
+++ b/src/AvPurplePen/UIText.resx
@@ -3556,6 +3556,24 @@ For printing competition maps, it is suggested that courses be exported to OCAD 
   <data name="SetPrintAreaDialog_checkBoxFixSizeToPaper_Text" xml:space="preserve">
     <value>Fix Print Area Size to Paper Size</value>
   </data>
+  <data name="PaperSizeControl_sizeLabel_Text" xml:space="preserve">
+    <value>Size:</value>
+  </data>
+  <data name="PaperSizeControl_widthLabel_Text" xml:space="preserve">
+    <value>Width:</value>
+  </data>
+  <data name="PaperSizeControl_heightLabel_Text" xml:space="preserve">
+    <value>Height:</value>
+  </data>
+  <data name="PaperSizeControl_marginLabel_Text" xml:space="preserve">
+    <value>Margin (all sides):</value>
+  </data>
+  <data name="PaperSizeControl_portraitLabel_Text" xml:space="preserve">
+    <value>Portrait</value>
+  </data>
+  <data name="PaperSizeControl_landscapeLabel_Text" xml:space="preserve">
+    <value>Landscape</value>
+  </data>
   <data name="SetUILanguage_introLabel_Text" xml:space="preserve">
     <value>Select the language that you would like to use for the user interface of Purple Pen (menus, windows, etc.)</value>
   </data>

--- a/src/AvPurplePen/Views/Dialogs/SetPrintAreaDialog.axaml
+++ b/src/AvPurplePen/Views/Dialogs/SetPrintAreaDialog.axaml
@@ -1,0 +1,165 @@
+<!--
+    SetPrintAreaDialog.axaml
+
+    Dialog for setting the print area rectangle for a course or all courses.
+    Lets the user choose a paper size, margin, and orientation, and toggle
+    whether the print area is set automatically or fixed to the paper size.
+
+    Migrated from WinForms PurplePen/SetPrintAreaDialog.cs and PaperSizeControl.cs.
+-->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:PurplePen.ViewModels"
+        xmlns:resx="using:AvPurplePen"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        x:Class="AvPurplePen.Views.SetPrintAreaDialog"
+        Classes="dialog"
+        x:DataType="vm:SetPrintAreaDialogViewModel"
+        Title="{resx:Localize SetPrintAreaDialog_Text}"
+        Icon="/Assets/transparent.ico"
+        d:DesignWidth="340" d:DesignHeight="360"
+        Width="340"
+        SizeToContent="Height"
+        CanResize="False"
+        CanMinimize="False"
+        CanMaximize="False"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False">
+
+    <Design.DataContext>
+        <vm:SetPrintAreaDialogViewModel/>
+    </Design.DataContext>
+
+    <DockPanel Margin="12">
+
+        <!-- OK / Cancel buttons at the bottom -->
+        <StackPanel DockPanel.Dock="Bottom"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="8"
+                    Margin="0,12,0,0">
+            <Button x:Name="cancelButton"
+                    Content="{resx:Localize SetPrintAreaDialog_cancelButton_Text}"
+                    Width="85"
+                    HorizontalContentAlignment="Center"
+                    IsCancel="True"
+                    Click="CancelButton_Click"/>
+            <Button x:Name="okButton"
+                    Content="{resx:Localize SetPrintAreaDialog_okButton_Text}"
+                    Width="85"
+                    HorizontalContentAlignment="Center"
+                    IsDefault="True"
+                    Click="OkButton_Click"/>
+        </StackPanel>
+
+        <!-- Main content -->
+        <StackPanel Spacing="8">
+
+            <!-- Paper Size group -->
+            <HeaderedContentControl Header="{resx:Localize SetPrintAreaDialog_groupBoxPaperSize_Text}"
+                                    Padding="8">
+                <StackPanel Spacing="6">
+
+                    <!-- Size combo row -->
+                    <Grid ColumnDefinitions="Auto,*">
+                        <TextBlock Grid.Column="0"
+                                   Text="{resx:Localize PaperSizeControl_sizeLabel_Text}"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,8,0"/>
+                        <ComboBox x:Name="paperSizeCombo"
+                                  Grid.Column="1"
+                                  ItemsSource="{Binding PaperSizeNames}"
+                                  SelectedIndex="{Binding SelectedPaperSizeIndex, Mode=TwoWay}"
+                                  HorizontalAlignment="Stretch"/>
+                    </Grid>
+
+                    <!-- Width / Height row -->
+                    <Grid ColumnDefinitions="Auto,80,Auto,Auto,80,Auto">
+                        <TextBlock Grid.Column="0"
+                                   Text="{resx:Localize PaperSizeControl_widthLabel_Text}"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,4,0"/>
+                        <NumericUpDown x:Name="upDownWidth"
+                                       Grid.Column="1"
+                                       Value="{Binding PageWidthValue, Mode=TwoWay}"
+                                       Minimum="0"
+                                       Maximum="{Binding MaxDimension}"
+                                       FormatString="{Binding FormatString}"
+                                       Increment="{Binding Increment}"
+                                       IsEnabled="{Binding IsUserDefinedSize}"/>
+                        <TextBlock Grid.Column="2"
+                                   Text="{Binding UnitLabel}"
+                                   VerticalAlignment="Center"
+                                   Margin="4,0,12,0"/>
+                        <TextBlock Grid.Column="3"
+                                   Text="{resx:Localize PaperSizeControl_heightLabel_Text}"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,4,0"/>
+                        <NumericUpDown x:Name="upDownHeight"
+                                       Grid.Column="4"
+                                       Value="{Binding PageHeightValue, Mode=TwoWay}"
+                                       Minimum="0"
+                                       Maximum="{Binding MaxDimension}"
+                                       FormatString="{Binding FormatString}"
+                                       Increment="{Binding Increment}"
+                                       IsEnabled="{Binding IsUserDefinedSize}"/>
+                        <TextBlock Grid.Column="5"
+                                   Text="{Binding UnitLabel}"
+                                   VerticalAlignment="Center"
+                                   Margin="4,0,0,0"/>
+                    </Grid>
+
+                    <!-- Margin row -->
+                    <Grid ColumnDefinitions="Auto,80,Auto">
+                        <TextBlock Grid.Column="0"
+                                   Text="{resx:Localize PaperSizeControl_marginLabel_Text}"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,4,0"/>
+                        <NumericUpDown x:Name="upDownMargin"
+                                       Grid.Column="1"
+                                       Value="{Binding PageMarginsValue, Mode=TwoWay}"
+                                       Minimum="0"
+                                       Maximum="{Binding MaxDimension}"
+                                       FormatString="{Binding FormatString}"
+                                       Increment="{Binding Increment}"/>
+                        <TextBlock Grid.Column="2"
+                                   Text="{Binding UnitLabel}"
+                                   VerticalAlignment="Center"
+                                   Margin="4,0,0,0"/>
+                    </Grid>
+
+                    <!-- Portrait / Landscape row -->
+                    <StackPanel Orientation="Horizontal" Spacing="16">
+                        <RadioButton x:Name="portraitRadio"
+                                     Content="{resx:Localize PaperSizeControl_portraitLabel_Text}"
+                                     IsChecked="{Binding IsPortrait, Mode=TwoWay}"/>
+                        <RadioButton x:Name="landscapeRadio"
+                                     Content="{resx:Localize PaperSizeControl_landscapeLabel_Text}"
+                                     IsChecked="{Binding Landscape, Mode=TwoWay}"/>
+                    </StackPanel>
+
+                </StackPanel>
+            </HeaderedContentControl>
+
+            <!-- Automatic checkbox -->
+            <CheckBox x:Name="checkBoxAutomatic"
+                      Content="{resx:Localize SetPrintAreaDialog_checkBoxAutomatic_Text}"
+                      IsChecked="{Binding AutoPrintArea, Mode=TwoWay}"/>
+
+            <!-- Fix size to paper checkbox -->
+            <CheckBox x:Name="checkBoxFixSizeToPaper"
+                      Content="{resx:Localize SetPrintAreaDialog_checkBoxFixSizeToPaper_Text}"
+                      IsChecked="{Binding RestrictToPageSize, Mode=TwoWay}"/>
+
+            <!-- Instruction label -->
+            <TextBlock Text="{resx:Localize SetPrintAreaDialog_setPrintAreaLabel_Text}"
+                       TextWrapping="Wrap"
+                       Margin="0,4,0,0"/>
+
+        </StackPanel>
+
+    </DockPanel>
+
+</Window>

--- a/src/AvPurplePen/Views/Dialogs/SetPrintAreaDialog.axaml.cs
+++ b/src/AvPurplePen/Views/Dialogs/SetPrintAreaDialog.axaml.cs
@@ -1,0 +1,49 @@
+// SetPrintAreaDialog.axaml.cs
+//
+// Code-behind for the Set Print Area dialog.
+// Handles Done/Cancel button clicks, delegating controller interaction
+// to the ViewModel.
+//
+// Migrated from WinForms PurplePen/SetPrintAreaDialog.cs.
+
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using PurplePen.ViewModels;
+
+namespace AvPurplePen.Views
+{
+    /// <summary>
+    /// Dialog for setting the print area rectangle for a course or all courses.
+    /// The caller must set DataContext to a SetPrintAreaDialogViewModel before showing.
+    /// </summary>
+    public partial class SetPrintAreaDialog : Window
+    {
+        /// <summary>
+        /// Initializes the dialog and its components.
+        /// </summary>
+        public SetPrintAreaDialog()
+        {
+            InitializeComponent();
+        }
+
+        /// <summary>
+        /// Commits the print area to the event database and closes the dialog.
+        /// </summary>
+        private void OkButton_Click(object? sender, RoutedEventArgs e)
+        {
+            SetPrintAreaDialogViewModel? vm = DataContext as SetPrintAreaDialogViewModel;
+            vm?.OnOk();
+            Close(true);
+        }
+
+        /// <summary>
+        /// Cancels the print area operation and closes the dialog.
+        /// </summary>
+        private void CancelButton_Click(object? sender, RoutedEventArgs e)
+        {
+            SetPrintAreaDialogViewModel? vm = DataContext as SetPrintAreaDialogViewModel;
+            vm?.OnCancel();
+            Close(false);
+        }
+    }
+}

--- a/src/PurplePenViewModels/MainWindowViewModel_Commands.cs
+++ b/src/PurplePenViewModels/MainWindowViewModel_Commands.cs
@@ -1598,33 +1598,39 @@ namespace PurplePen.ViewModels
         /// Sets the print area for this part only.
         /// </summary>
         [RelayCommand]
-        private void SetPrintAreaThisPart()
+        private async Task SetPrintAreaThisPart()
         {
-#if !PORTING
-            SetPrintArea(PrintAreaKind.OnePart);
-#endif
+            await SetPrintAreaAsync(PrintAreaKind.OnePart);
         }
 
         /// <summary>
         /// Sets the print area for this course only.
         /// </summary>
         [RelayCommand]
-        private void SetPrintAreaThisCourse()
+        private async Task SetPrintAreaThisCourse()
         {
-#if !PORTING
-            SetPrintArea(PrintAreaKind.OneCourse);
-#endif
+            await SetPrintAreaAsync(PrintAreaKind.OneCourse);
         }
 
         /// <summary>
         /// Sets the print area for all courses.
         /// </summary>
         [RelayCommand]
-        private void SetPrintAreaAllCourses()
+        private async Task SetPrintAreaAllCourses()
         {
-#if !PORTING
-            SetPrintArea(PrintAreaKind.AllCourses);
-#endif
+            await SetPrintAreaAsync(PrintAreaKind.AllCourses);
+        }
+
+        /// <summary>
+        /// Shows the Set Print Area dialog for the given scope and commits any changes.
+        /// </summary>
+        /// <param name="printAreaKind">Which scope of print area to edit.</param>
+        private async Task SetPrintAreaAsync(PrintAreaKind printAreaKind)
+        {
+            if (controller == null) return;
+            SetPrintAreaDialogViewModel vm = new SetPrintAreaDialogViewModel(controller, printAreaKind);
+            await Services.DialogService.ShowDialogAsync(vm);
+            // OnOk / OnCancel on the ViewModel handle the controller interaction.
         }
 
         #endregion // Print area commands

--- a/src/PurplePenViewModels/SetPrintAreaDialogViewModel.cs
+++ b/src/PurplePenViewModels/SetPrintAreaDialogViewModel.cs
@@ -1,0 +1,321 @@
+// SetPrintAreaDialogViewModel.cs
+//
+// ViewModel for the Set Print Area dialog. Exposes paper size, margin,
+// orientation, and print area mode options as bindable properties.
+// Communicates with the controller to preview and commit the print area.
+//
+// Ported from WinForms PurplePen/SetPrintAreaDialog.cs.
+
+using System;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace PurplePen.ViewModels
+{
+    /// <summary>
+    /// ViewModel for the Set Print Area dialog.
+    /// The caller must provide a Controller and PrintAreaKind via the runtime constructor.
+    /// </summary>
+    public partial class SetPrintAreaDialogViewModel : ViewModelBase
+    {
+        private readonly Controller? _controller;
+        private readonly PrintAreaKind _printAreaKind;
+        private PrintArea _printArea;
+        private readonly PrintingPaperSize[] _standardSizes;
+        private bool _updateInProgress;
+
+        // Index of the "User Defined" entry at the end of PaperSizeNames.
+        private int _userDefinedIndex;
+
+        // ── Paper size combo ──────────────────────────────────────────────
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(IsUserDefinedSize))]
+        private int selectedPaperSizeIndex = 0;
+
+        // ── Width / Height / Margin in user units (mm or in) ─────────────
+
+        [ObservableProperty]
+        private decimal pageWidthValue = 0;
+
+        [ObservableProperty]
+        private decimal pageHeightValue = 0;
+
+        [ObservableProperty]
+        private decimal pageMarginsValue = 0;
+
+        // ── Orientation ───────────────────────────────────────────────────
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(IsPortrait))]
+        private bool landscape = false;
+
+        // ── Checkboxes ────────────────────────────────────────────────────
+
+        [ObservableProperty]
+        private bool autoPrintArea = true;
+
+        [ObservableProperty]
+        private bool restrictToPageSize = true;
+
+        // ── Unit display ──────────────────────────────────────────────────
+
+        /// <summary>Label string shown after width/height/margin fields ("mm" or "in").</summary>
+        public string UnitLabel => Util.IsCurrentCultureMetric() ? "mm" : "in";
+
+        /// <summary>Format string for numeric up-downs (e.g. "0.0" or "0.00").</summary>
+        public string FormatString => Util.IsCurrentCultureMetric() ? "0.0" : "0.00";
+
+        /// <summary>Step increment for numeric up-downs.</summary>
+        public decimal Increment => Util.IsCurrentCultureMetric() ? 1.0m : 0.05m;
+
+        /// <summary>Maximum dimension value for numeric up-downs.</summary>
+        public decimal MaxDimension => Util.IsCurrentCultureMetric() ? 5000m : 200m;
+
+        /// <summary>True when Portrait orientation is selected (inverse of Landscape).</summary>
+        public bool IsPortrait
+        {
+            get => !Landscape;
+            set => Landscape = !value;
+        }
+
+        // ── Computed ──────────────────────────────────────────────────────
+
+        /// <summary>True when the last paper size entry ("User Defined") is selected.</summary>
+        public bool IsUserDefinedSize => SelectedPaperSizeIndex == _userDefinedIndex;
+
+        /// <summary>Items for the paper size combo box.</summary>
+        public ObservableCollection<string> PaperSizeNames { get; } = new();
+
+        // ── Design-time constructor ───────────────────────────────────────
+
+        /// <summary>Parameterless constructor for the Avalonia designer.</summary>
+        public SetPrintAreaDialogViewModel()
+        {
+            _standardSizes = PrintingStandards.StandardPaperSizes;
+            _printArea = PrintArea.DefaultPrintArea;
+            _controller = null;
+            _printAreaKind = PrintAreaKind.OneCourse;
+            InitPaperSizeNames();
+            UpdateDialogControls();
+        }
+
+        // ── Runtime constructor ───────────────────────────────────────────
+
+        /// <summary>
+        /// Runtime constructor.
+        /// Loads the current print area from the controller and begins the interactive mode.
+        /// </summary>
+        /// <param name="controller">Application controller.</param>
+        /// <param name="printAreaKind">Which scope of print area is being edited.</param>
+        public SetPrintAreaDialogViewModel(Controller controller, PrintAreaKind printAreaKind)
+        {
+            _controller = controller;
+            _printAreaKind = printAreaKind;
+            _standardSizes = PrintingStandards.StandardPaperSizes;
+            _printArea = (PrintArea)controller.GetCurrentPrintArea(printAreaKind).Clone();
+
+            InitPaperSizeNames();
+            UpdateDialogControls();
+
+            // Put the controller into rectangle-select mode so it draws the print area overlay.
+            controller.BeginSetPrintArea(printAreaKind, new NoopDisposable());
+            // Push current print area to controller for the initial preview.
+            SendPrintAreaUpdate();
+        }
+
+        // ── Internal helpers ──────────────────────────────────────────────
+
+        /// <summary>Populates PaperSizeNames from the standard sizes plus a "User Defined" entry.</summary>
+        private void InitPaperSizeNames()
+        {
+            PaperSizeNames.Clear();
+            foreach (PrintingPaperSize ps in _standardSizes)
+                PaperSizeNames.Add(Util.GetPaperSizeText(ps));
+            PaperSizeNames.Add(MiscText.UserDefined);
+            _userDefinedIndex = PaperSizeNames.Count - 1;
+        }
+
+        /// <summary>Populates all dialog controls from the current _printArea model.</summary>
+        private void UpdateDialogControls()
+        {
+            _updateInProgress = true;
+
+            AutoPrintArea = _printArea.autoPrintArea;
+            RestrictToPageSize = _printArea.restrictToPageSize;
+
+            int pageW = _printArea.pageWidth;
+            int pageH = _printArea.pageHeight;
+
+            if (pageW > 0 && pageH > 0) {
+                // Find a matching standard size (ignoring orientation — compare short vs long sides).
+                int bestIndex = _userDefinedIndex;
+                for (int i = 0; i < _standardSizes.Length; i++) {
+                    int sw = (int)Math.Round(_standardSizes[i].SizeInHundreths.Width);
+                    int sh = (int)Math.Round(_standardSizes[i].SizeInHundreths.Height);
+                    if ((sw == pageW && sh == pageH) || (sw == pageH && sh == pageW)) {
+                        bestIndex = i;
+                        break;
+                    }
+                }
+                SelectedPaperSizeIndex = bestIndex;
+                Landscape = _printArea.pageLandscape;
+                PageWidthValue = Util.GetDistanceValue(pageW);
+                PageHeightValue = Util.GetDistanceValue(pageH);
+            }
+
+            PageMarginsValue = Util.GetDistanceValue(_printArea.pageMargins);
+
+            _updateInProgress = false;
+        }
+
+        /// <summary>Reads control state back into _printArea.</summary>
+        private void UpdatePrintArea()
+        {
+            _printArea.autoPrintArea = AutoPrintArea;
+            _printArea.restrictToPageSize = RestrictToPageSize;
+            _printArea.pageLandscape = Landscape;
+            _printArea.pageMargins = Util.GetDistanceFromValue(PageMarginsValue);
+
+            if (IsUserDefinedSize) {
+                _printArea.pageWidth = Util.GetDistanceFromValue(PageWidthValue);
+                _printArea.pageHeight = Util.GetDistanceFromValue(PageHeightValue);
+            }
+            else if (SelectedPaperSizeIndex >= 0 && SelectedPaperSizeIndex < _standardSizes.Length) {
+                PrintingPaperSize ps = _standardSizes[SelectedPaperSizeIndex];
+                // Swap width/height if landscape orientation differs from the canonical size.
+                bool effectiveLandscape = Landscape != ps.Landscape;
+                if (effectiveLandscape) {
+                    _printArea.pageWidth = (int)Math.Round(ps.SizeInHundreths.Height);
+                    _printArea.pageHeight = (int)Math.Round(ps.SizeInHundreths.Width);
+                }
+                else {
+                    _printArea.pageWidth = (int)Math.Round(ps.SizeInHundreths.Width);
+                    _printArea.pageHeight = (int)Math.Round(ps.SizeInHundreths.Height);
+                }
+            }
+
+            if (_controller != null)
+                _printArea.printAreaRectangle = _controller.SetPrintAreaCurrentRectangle();
+        }
+
+        /// <summary>Pushes current print area settings to the controller for live preview.</summary>
+        private void SendPrintAreaUpdate()
+        {
+            UpdatePrintArea();
+            _controller?.SetPrintAreaUpdate(_printAreaKind, _printArea);
+        }
+
+        // ── Property-change callbacks ─────────────────────────────────────
+
+        partial void OnSelectedPaperSizeIndexChanged(int value)
+        {
+            if (_updateInProgress)
+                return;
+
+            // Sync the displayed width/height to the newly selected standard size.
+            if (!IsUserDefinedSize && value >= 0 && value < _standardSizes.Length) {
+                _updateInProgress = true;
+                PrintingPaperSize ps = _standardSizes[value];
+                bool effectiveLandscape = Landscape != ps.Landscape;
+                PageWidthValue = Util.GetDistanceValue(effectiveLandscape
+                    ? (int)Math.Round(ps.SizeInHundreths.Height)
+                    : (int)Math.Round(ps.SizeInHundreths.Width));
+                PageHeightValue = Util.GetDistanceValue(effectiveLandscape
+                    ? (int)Math.Round(ps.SizeInHundreths.Width)
+                    : (int)Math.Round(ps.SizeInHundreths.Height));
+                _updateInProgress = false;
+            }
+
+            SendPrintAreaUpdate();
+        }
+
+        partial void OnLandscapeChanged(bool value)
+        {
+            if (_updateInProgress)
+                return;
+
+            // Swap displayed width/height when flipping orientation on a standard size.
+            if (!IsUserDefinedSize && SelectedPaperSizeIndex >= 0 && SelectedPaperSizeIndex < _standardSizes.Length) {
+                _updateInProgress = true;
+                decimal tmp = PageWidthValue;
+                PageWidthValue = PageHeightValue;
+                PageHeightValue = tmp;
+                _updateInProgress = false;
+            }
+
+            SendPrintAreaUpdate();
+        }
+
+        partial void OnAutoPrintAreaChanged(bool value)
+        {
+            if (_updateInProgress)
+                return;
+
+            if (!value && _controller != null) {
+                // Switching from auto to manual: pre-fill with the auto-generated rectangle.
+                UpdatePrintArea();
+                _printArea.autoPrintArea = true;
+                _printArea.printAreaRectangle = _controller.GetPrintAreaRectangle(_printAreaKind, _printArea);
+                _printArea.autoPrintArea = false;
+            }
+
+            SendPrintAreaUpdate();
+        }
+
+        partial void OnRestrictToPageSizeChanged(bool value)
+        {
+            if (!_updateInProgress)
+                SendPrintAreaUpdate();
+        }
+
+        partial void OnPageWidthValueChanged(decimal value)
+        {
+            if (!_updateInProgress)
+                SendPrintAreaUpdate();
+        }
+
+        partial void OnPageHeightValueChanged(decimal value)
+        {
+            if (!_updateInProgress)
+                SendPrintAreaUpdate();
+        }
+
+        partial void OnPageMarginsValueChanged(decimal value)
+        {
+            if (!_updateInProgress)
+                SendPrintAreaUpdate();
+        }
+
+        // ── Dialog actions ────────────────────────────────────────────────
+
+        /// <summary>
+        /// Called by the code-behind when the user clicks Done.
+        /// Commits the print area to the event database via the controller.
+        /// </summary>
+        public void OnOk()
+        {
+            UpdatePrintArea();
+            if (_controller != null)
+                _printArea.printAreaRectangle = _controller.SetPrintAreaCurrentRectangle();
+            _controller?.EndSetPrintArea(_printAreaKind, _printArea);
+        }
+
+        /// <summary>
+        /// Called by the code-behind when the user clicks Cancel.
+        /// Reverts the controller to its default mode.
+        /// </summary>
+        public void OnCancel()
+        {
+            _controller?.CancelMode();
+        }
+
+        // ── Private helpers ───────────────────────────────────────────────
+
+        /// <summary>IDisposable with a no-op Dispose, passed to BeginSetPrintArea.</summary>
+        private sealed class NoopDisposable : IDisposable
+        {
+            public void Dispose() { }
+        }
+    }
+}


### PR DESCRIPTION
Closes #4

## Summary

- Ports `SetPrintAreaDialog` and the inline `PaperSizeControl` from WinForms to Avalonia following the project porting workflow
- `SetPrintAreaDialogViewModel` manages paper size, margin, orientation, auto print area, and fix-size-to-paper state; communicates with the controller for live preview and final commit
- `SetPrintAreaDialog.axaml` / `.axaml.cs` — modal Window replacing the non-modal WinForms dialog
- Removes `#if !PORTING` guards from the three Set Print Area relay commands in `MainWindowViewModel_Commands.cs`
- Adds 6 `PaperSizeControl_*` string keys to `UIText.resx`

**Behavior change:** The WinForms dialog was non-modal (users could drag the print area rectangle on the map while the dialog was open). The Avalonia version is modal via `IDialogService.ShowDialogAsync`. Rectangle dragging is not available while the dialog is open; all paper settings and auto/fix-size toggles are fully functional.

## Test plan

- [ ] Open via Course → Set Print Area → This Course / All Courses / This Part — dialog opens with current paper size and settings
- [ ] Select each standard paper size — Width/Height update and become read-only; "User Defined" makes them editable
- [ ] Toggle Portrait ↔ Landscape — Width/Height swap for standard sizes
- [ ] Change margin — value round-trips correctly in metric and imperial locales
- [ ] Uncheck "Set Print Area Automatically" — dialog pre-fills rectangle with auto-generated area
- [ ] Click Done — print area saved; Cmd+Z undoes it
- [ ] Click Cancel — no change recorded, undo stack unchanged
- [ ] Run with a non-English locale — no crash from missing translated `PaperSizeControl_*` keys (English fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)