### PR TITLE
feat: port LicenseDialog and wire up help system in AboutDialog (fixes #13)

### DIFF
--- a/src/AvPurplePen/AvPurplePen.csproj
+++ b/src/AvPurplePen/AvPurplePen.csproj
@@ -19,6 +19,13 @@
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="..\..\doc\userdocs\Help\Credits.htm">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Help\Credits.htm</Link>
+    </Content>
+  </ItemGroup>
+
   <!-- Exclude ImageSharp from ReadyToRun — it grows from 1.7 MB to 30 MB
        and is only used for metadata/format detection, not on the hot path. -->
   <ItemGroup>

--- a/src/AvPurplePen/Views/Dialogs/AboutDialog.axaml.cs
+++ b/src/AvPurplePen/Views/Dialogs/AboutDialog.axaml.cs
@@ -7,7 +7,9 @@
 // Migrated from WinForms PurplePen/AboutForm.cs.
 
 using System;
+using System.Diagnostics;
 using System.Drawing;
+using System.IO;
 using System.Runtime.InteropServices;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -35,23 +37,26 @@ namespace AvPurplePen.Views
         /// <summary>
         /// Opens the license dialog.
         /// </summary>
-        private void LicenseButton_Click(object? sender, RoutedEventArgs e)
+        private async void LicenseButton_Click(object? sender, RoutedEventArgs e)
         {
-#if PORTING
-            // TODO: Create Avalonia LicenseDialog and show it here.
-            // Original: new LicenseForm().ShowDialog();
-#endif
+            LicenseDialog dialog = new LicenseDialog();
+            await dialog.ShowDialog(this);
         }
 
         /// <summary>
-        /// Opens the Credits help topic.
+        /// Opens Credits.htm from the Help folder in the default browser.
         /// </summary>
         private void CreditsButton_Click(object? sender, RoutedEventArgs e)
         {
-#if PORTING
-            // TODO: Wire up help system for Avalonia.
-            // Original: WindowsUtil.ShowHelpTopic(this, "Credits.htm");
-#endif
+            string creditsPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Help", "Credits.htm");
+            if (File.Exists(creditsPath))
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = creditsPath,
+                    UseShellExecute = true
+                });
+            }
         }
 
         /// <summary>

--- a/src/AvPurplePen/Views/Dialogs/AboutDialog.axaml.cs
+++ b/src/AvPurplePen/Views/Dialogs/AboutDialog.axaml.cs
@@ -49,14 +49,11 @@ namespace AvPurplePen.Views
         private void CreditsButton_Click(object? sender, RoutedEventArgs e)
         {
             string creditsPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Help", "Credits.htm");
-            if (File.Exists(creditsPath))
+            Process.Start(new ProcessStartInfo
             {
-                Process.Start(new ProcessStartInfo
-                {
-                    FileName = creditsPath,
-                    UseShellExecute = true
-                });
-            }
+                FileName = creditsPath,
+                UseShellExecute = true
+            });
         }
 
         /// <summary>

--- a/src/AvPurplePen/Views/Dialogs/LicenseDialog.axaml
+++ b/src/AvPurplePen/Views/Dialogs/LicenseDialog.axaml
@@ -1,0 +1,62 @@
+<!--
+    LicenseDialog.axaml
+
+    Displays the Purple Pen BSD license text in a scrollable, read-only area,
+    with a link to the Wikipedia BSD License page and an OK button to dismiss.
+
+    Migrated from WinForms PurplePen/LicenseForm.cs.
+-->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:resx="using:AvPurplePen"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        d:DesignWidth="502" d:DesignHeight="354"
+        x:Class="AvPurplePen.Views.LicenseDialog"
+        Classes="dialog"
+        Title="{resx:Localize LicenseForm_Text}"
+        Width="502" Height="354"
+        CanResize="True"
+        CanMaximize="False"
+        CanMinimize="False"
+        Icon="/Assets/transparent.ico"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        SystemDecorations="Full">
+
+    <DockPanel Margin="12">
+
+        <!-- Bottom row: BSD link label on the left, OK button on the right -->
+        <Grid DockPanel.Dock="Bottom"
+              Margin="0,8,0,0"
+              ColumnDefinitions="*,Auto">
+
+            <Button x:Name="bsdLicenseLinkButton"
+                    Grid.Column="0"
+                    Content="{resx:Localize LicenseForm_bsdLicenseLinkLabel_Text}"
+                    HorizontalAlignment="Left"
+                    HorizontalContentAlignment="Left"
+                    Classes="hyperlink"
+                    Click="BsdLicenseLinkButton_Click"/>
+
+            <Button x:Name="okButton"
+                    Grid.Column="1"
+                    Content="{resx:Localize LicenseForm_okButton_Text}"
+                    MinWidth="80"
+                    HorizontalContentAlignment="Center"
+                    IsDefault="True"
+                    Click="OkButton_Click"/>
+        </Grid>
+
+        <!-- License text fills the remaining space -->
+        <ScrollViewer>
+            <SelectableTextBlock x:Name="licenseTextBlock"
+                                 TextWrapping="Wrap"
+                                 FontFamily="Times New Roman"
+                                 FontSize="13"/>
+        </ScrollViewer>
+
+    </DockPanel>
+
+</Window>

--- a/src/AvPurplePen/Views/Dialogs/LicenseDialog.axaml.cs
+++ b/src/AvPurplePen/Views/Dialogs/LicenseDialog.axaml.cs
@@ -1,0 +1,74 @@
+// LicenseDialog.axaml.cs
+//
+// Code-behind for the Purple Pen license dialog. Displays the BSD license
+// text and provides a link to the BSD License Wikipedia page.
+//
+// Migrated from WinForms PurplePen/LicenseForm.cs.
+
+using System.Diagnostics;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace AvPurplePen.Views
+{
+    /// <summary>
+    /// Read-only dialog that displays the Purple Pen BSD license text.
+    /// No DataContext or ViewModel required.
+    /// </summary>
+    public partial class LicenseDialog : Window
+    {
+        // Plain-text BSD license; converted from the RTF content in WinForms LicenseForm.cs.
+        private const string LicenseText =
+            "Copyright © 2007-2012, Peter Golde\r\n" +
+            "All rights reserved.\r\n\r\n" +
+            "Redistribution and use in source and binary forms, with or without " +
+            "modification, are permitted provided that the following conditions are met:\r\n\r\n" +
+            "•  Redistributions of source code must retain the above copyright notice, " +
+            "this list of conditions and the following disclaimer.\r\n\r\n" +
+            "•  Redistributions in binary form must reproduce the above copyright notice, " +
+            "this list of conditions and the following disclaimer in the documentation " +
+            "and/or other materials provided with the distribution.\r\n\r\n" +
+            "•  Neither the name of Peter Golde, nor \"Purple Pen\", nor the names of its " +
+            "contributors may be used to endorse or promote products derived from this " +
+            "software without specific prior written permission.\r\n\r\n" +
+            "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" " +
+            "AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE " +
+            "IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE " +
+            "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR " +
+            "ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES " +
+            "(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; " +
+            "LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON " +
+            "ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT " +
+            "(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS " +
+            "SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.";
+
+        /// <summary>
+        /// Initializes the dialog and populates the license text.
+        /// </summary>
+        public LicenseDialog()
+        {
+            InitializeComponent();
+            licenseTextBlock.Text = LicenseText;
+        }
+
+        /// <summary>
+        /// Opens the BSD License Wikipedia article in the default browser.
+        /// </summary>
+        private void BsdLicenseLinkButton_Click(object? sender, RoutedEventArgs e)
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "http://en.wikipedia.org/wiki/BSD_License",
+                UseShellExecute = true
+            });
+        }
+
+        /// <summary>
+        /// Closes the dialog.
+        /// </summary>
+        private void OkButton_Click(object? sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Creates `LicenseDialog.axaml` / `LicenseDialog.axaml.cs` — Avalonia dialog displaying the BSD license text in a scrollable read-only area, with a hyperlink button that opens the Wikipedia BSD License page in the system default browser
- Removes the two `#if PORTING` stubs in `AboutDialog.axaml.cs`:
  - `LicenseButton_Click` now opens `LicenseDialog` as a modal
  - `CreditsButton_Click` now opens `Credits.htm` from the `Help` folder using `Process.Start { UseShellExecute = true }` (cross-platform)

No UIText.resx changes required — all three needed keys already existed.

## Test plan

- [x] Build passes: `dotnet build src/AvPurplePen/AvPurplePen.csproj`
- [x] About dialog → "View Full License" → LicenseDialog opens with scrollable BSD text
- [x] Click link in LicenseDialog → Wikipedia BSD License page opens in browser
- [x] OK closes LicenseDialog
- [x] About dialog → "Credits" → Credits.htm opens in default browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)