### PR TITLE
fix: upgrade Avalonia to 11.3.14 to resolve NU1903 Tmds.DBus.Protocol vulnerability

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -34,15 +34,15 @@
     <PackageVersion Include="PDFiumCore" Version="134.0.6982" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.3" />
     
-    <PackageVersion Include="Avalonia" Version="11.3.11" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.11" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.11" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.11" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.11" />
+    <PackageVersion Include="Avalonia" Version="11.3.14" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.3.14" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.14" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.14" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.14" />
 
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.1" />
 
-    <PackageVersion Include="Semi.Avalonia" Version="11.3.7" />
+    <PackageVersion Include="Semi.Avalonia" Version="11.3.14" />
 
     <!-- 
     Do not upgrade ImageSharp past 2.1.3! Later versions have a stricter license. We want the Apache 2.0 license. 


### PR DESCRIPTION
## Summary

- Bumps `Avalonia*` packages from 11.3.11 → 11.3.14 in `src/Directory.Packages.props`
- Bumps `Semi.Avalonia` from 11.3.7 → 11.3.14 to match
- Avalonia 11.3.14 ships `Avalonia.FreeDesktop` with `Tmds.DBus.Protocol` 0.21.3, patching [GHSA-xrw6-gwf8-vvr9](https://github.com/advisories/GHSA-xrw6-gwf8-vvr9) (high severity NU1903 warning)

Closes #23

## Test plan

- [x] `dotnet restore AvPurplePen/AvPurplePen.csproj` — clean, no NU1903 warning
- [x] `dotnet nuget why AvPurplePen/AvPurplePen.csproj Tmds.DBus.Protocol` — confirms resolved version is 0.21.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)